### PR TITLE
[Feature] MCP Tools for the Inference Recommender Jobs

### DIFF
--- a/sagemaker_ai_mcp_server/helpers.py
+++ b/sagemaker_ai_mcp_server/helpers.py
@@ -3,7 +3,7 @@
 import boto3
 import os
 from loguru import logger
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal
 
 
 # Helper Functions for the region, session and client creation

--- a/sagemaker_ai_mcp_server/helpers.py
+++ b/sagemaker_ai_mcp_server/helpers.py
@@ -3,7 +3,7 @@
 import boto3
 import os
 from loguru import logger
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional
 
 
 # Helper Functions for the region, session and client creation
@@ -751,3 +751,63 @@ async def list_model_card_versions(model_card_name: str) -> List[Dict[str, Any]]
     logger.info(f'Listing versions for Model Card: {model_card_name}')
     response = client.list_model_card_versions(ModelCardName=model_card_name)
     return response.get('ModelCardVersionSummaryList', [])
+
+
+# Helper Functions for SageMaker AI Inference Recommender Jobs
+
+
+async def list_inference_recommendations_jobs() -> List[Dict[str, Any]]:
+    """List all SageMaker Inference Recommender Jobs.
+
+    Returns:
+        List[Dict[str, Any]]: A list of SageMaker Inference Recommender Jobs.
+    """
+    client = get_sagemaker_client()
+    logger.info('Listing SageMaker Inference Recommender Jobs...')
+    response = client.list_inference_recommendations_jobs()
+    return response.get('InferenceRecommendationsJobs', [])
+
+
+async def list_inference_recommendations_job_steps(job_name: str) -> List[Dict[str, Any]]:
+    """List steps for a specific SageMaker Inference Recommender Job.
+
+    Args:
+        job_name (str): The name of the SageMaker Inference Recommender Job.
+
+    Returns:
+        List[Dict[str, Any]]: A list of steps for the specified Inference
+        Recommender Job.
+    """
+    client = get_sagemaker_client()
+    logger.info(f'Listing steps for Inference Recommender Job: {job_name}')
+    response = client.list_inference_recommendations_job_steps(JobName=job_name)
+    return response.get('Steps', [])
+
+
+async def stop_inference_recommendations_job(job_name: str) -> None:
+    """Stop a SageMaker Inference Recommender Job.
+
+    Args:
+        job_name (str): The name of the SageMaker Inference Recommender Job
+            to stop.
+    """
+    client = get_sagemaker_client()
+    logger.info(f'Stopping SageMaker Inference Recommender Job: {job_name}')
+    client.stop_inference_recommendations_job(JobName=job_name)
+    logger.info(f'Inference Recommender Job {job_name} stopped successfully.')
+
+
+async def describe_inference_recommendations_job(job_name: str) -> Dict[str, Any]:
+    """Describe a SageMaker Inference Recommender Job.
+
+    Args:
+        job_name (str): The name of the SageMaker Inference Recommender Job
+            to describe.
+
+    Returns:
+        Dict[str, Any]: The details of the specified Inference Recommender Job.
+    """
+    client = get_sagemaker_client()
+    logger.info(f'Describing SageMaker Inference Recommender Job: {job_name}')
+    response = client.describe_inference_recommendations_job(JobName=job_name)
+    return response

--- a/sagemaker_ai_mcp_server/server.py
+++ b/sagemaker_ai_mcp_server/server.py
@@ -17,6 +17,7 @@ from sagemaker_ai_mcp_server.helpers import (
     describe_domain,
     describe_endpoint,
     describe_endpoint_config,
+    describe_inference_recommendations_job,
     describe_mlflow_tracking_server,
     describe_model,
     describe_model_card,
@@ -29,6 +30,8 @@ from sagemaker_ai_mcp_server.helpers import (
     list_domains,
     list_endpoint_configs,
     list_endpoints,
+    list_inference_recommendations_job_steps,
+    list_inference_recommendations_jobs,
     list_mlflow_tracking_servers,
     list_model_card_export_jobs,
     list_model_card_versions,
@@ -45,6 +48,7 @@ from sagemaker_ai_mcp_server.helpers import (
     list_user_profiles,
     start_mlflow_tracking_server,
     start_pipeline_execution,
+    stop_inference_recommendations_job,
     stop_mlflow_tracking_server,
     stop_pipeline_execution,
     stop_processing_job,
@@ -107,6 +111,10 @@ mcp = FastMCP(
     - Describe a Model Card Export Job in SageMaker
     - List Model Card Export Jobs in SageMaker
     - List Model Card Versions in SageMaker
+    - List Inference Recommender Jobs
+    - List Inference Recommender Job Steps
+    - Describe Inference Recommender Job
+    - Stop Inference Recommender Job
     Use these tools to manage your SageMaker resources effectively.
     """,
     dependencies=[
@@ -1861,6 +1869,165 @@ async def list_model_card_versions_sagemaker(
     except Exception as e:
         logger.error(f'Error listing model card versions for {model_card_name}: {e}')
         raise ValueError(f'Failed to list model card versions for {model_card_name}: {e}')
+
+
+@mcp.tool(
+    name='list_inference_recommendations_jobs_sagemaker',
+    description='List all SageMaker Inference Recommender Jobs',
+)
+async def list_inference_recommendations_jobs_sagemaker() -> Dict[str, List]:
+    """List all SageMaker Inference Recommender Jobs.
+
+    ## Usage
+
+    Use this tool to retrieve a list of all SageMaker Inference Recommender Jobs
+    in your account in the current region. This is typically used to see what
+    inference recommender jobs are available before performing operations on them.
+
+    ## Example
+
+    ```python
+    jobs = await list_inference_recommendations_jobs_sagemaker()
+    print(jobs)
+    ```
+
+    ## Output Format
+
+    The output is a dictionary with the following structure:
+    - 'inference_recommendations_jobs': A list of dictionaries, each representing
+      a SageMaker Inference Recommender Job with its details.
+
+    ## Returns
+    A dictionary containing a list of SageMaker Inference Recommender Jobs.
+    """
+    try:
+        jobs = await list_inference_recommendations_jobs()
+        return {'inference_recommendations_jobs': jobs}
+    except Exception as e:
+        logger.error(f'Error listing inference recommender jobs: {e}')
+        raise ValueError(f'Failed to list inference recommender jobs: {e}')
+
+
+@mcp.tool(
+    name='list_inference_recommendations_job_steps_sagemaker',
+    description='List steps for a SageMaker Inference Recommender Job',
+)
+async def list_inference_recommendations_job_steps_sagemaker(
+    job_name: Annotated[
+        str,
+        Field(description='The name of the SageMaker Inference Recommender Job to list steps for'),
+    ],
+) -> Dict[str, List]:
+    """List steps for a specific SageMaker Inference Recommender Job.
+
+    ## Usage
+
+    Use this tool to retrieve a list of steps for a specific SageMaker Inference
+    Recommender Job by providing its name. This helps you track the progress of the job.
+
+    ## Example
+
+    ```python
+    steps = await list_inference_recommendations_job_steps_sagemaker(job_name='my-inference-job')
+    print(steps)
+    ```
+
+    ## Output Format
+
+    The output is a dictionary with the following structure:
+    - 'steps': A list of dictionaries, each representing a step in the SageMaker
+      Inference Recommender Job with its details.
+
+    ## Returns
+    A dictionary containing a list of steps for the specified Inference Recommender Job.
+    """
+    try:
+        steps = await list_inference_recommendations_job_steps(job_name)
+        return {'steps': steps}
+    except Exception as e:
+        logger.error(f'Error listing steps for inference recommender job {job_name}: {e}')
+        raise ValueError(f'Failed to list steps for inference recommender job {job_name}: {e}')
+
+
+@mcp.tool(
+    name='describe_inference_recommendations_job_sagemaker',
+    description='Describe a SageMaker Inference Recommender Job',
+)
+async def describe_inference_recommendations_job_sagemaker(
+    job_name: Annotated[
+        str, Field(description='The name of the SageMaker Inference Recommender Job to describe')
+    ],
+) -> Dict[str, Any]:
+    """Describe a specified SageMaker Inference Recommender Job.
+
+    ## Usage
+
+    Use this tool to get detailed information about a SageMaker Inference
+    Recommender Job by providing its name. This returns comprehensive information
+    about the job's configuration, status, and other details.
+
+    ## Example
+
+    ```python
+    job_details = await describe_inference_recommendations_job_sagemaker(
+        job_name='my-inference-job'
+    )
+    print(job_details)
+    ```
+
+    ## Output Format
+
+    The output is a dictionary containing all the details of the SageMaker
+    Inference Recommender Job.
+
+    ## Returns
+    A dictionary containing the job details.
+    """
+    try:
+        job_details = await describe_inference_recommendations_job(job_name)
+        return {'job_details': job_details}
+    except Exception as e:
+        logger.error(f'Error describing inference recommender job {job_name}: {e}')
+        raise ValueError(f'Failed to describe inference recommender job {job_name}: {e}')
+
+
+@mcp.tool(
+    name='stop_inference_recommendations_job_sagemaker',
+    description='Stop a SageMaker Inference Recommender Job',
+)
+async def stop_inference_recommendations_job_sagemaker(
+    job_name: Annotated[
+        str, Field(description='The name of the SageMaker Inference Recommender Job to stop')
+    ],
+) -> Dict[str, str]:
+    """Stop a specified SageMaker Inference Recommender Job.
+
+    ## Usage
+
+    Use this tool to stop a SageMaker Inference Recommender Job by providing its name.
+    This is useful for stopping jobs that are no longer needed or are consuming
+    too many resources.
+
+    ## Example
+
+    ```python
+    result = await stop_inference_recommendations_job_sagemaker(job_name='my-inference-job')
+    print(result)
+    ```
+
+    ## Output Format
+
+    The output is a dictionary with a success message.
+
+    ## Returns
+    A dictionary containing a success message.
+    """
+    try:
+        await stop_inference_recommendations_job(job_name)
+        return {'message': f"Inference Recommender Job '{job_name}' stopped successfully"}
+    except Exception as e:
+        logger.error(f'Error stopping inference recommender job {job_name}: {e}')
+        raise ValueError(f'Failed to stop inference recommender job {job_name}: {e}')
 
 
 def main():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -976,7 +976,6 @@ class TestHelpers:
     @patch('sagemaker_ai_mcp_server.helpers.get_sagemaker_client')
     async def test_list_inference_recommendations_jobs(self, mock_get_sagemaker_client):
         """Test listing of SageMaker Inference Recommender Jobs."""
-
         mock_client = MagicMock()
         mock_client.list_inference_recommendations_jobs.return_value = {
             'InferenceRecommendationsJobs': [
@@ -997,7 +996,6 @@ class TestHelpers:
     @patch('sagemaker_ai_mcp_server.helpers.get_sagemaker_client')
     async def test_list_inference_recommendations_job_steps(self, mock_get_sagemaker_client):
         """Test listing steps for a specific SageMaker Inference Recommender Job."""
-
         job_name = 'test-job'
         mock_client = MagicMock()
         mock_client.list_inference_recommendations_job_steps.return_value = {
@@ -1033,7 +1031,6 @@ class TestHelpers:
     @patch('sagemaker_ai_mcp_server.helpers.get_sagemaker_client')
     async def test_describe_inference_recommendations_job(self, mock_get_sagemaker_client):
         """Test describing a SageMaker Inference Recommender Job."""
-
         job_name = 'test-job'
         mock_client = MagicMock()
         mock_client.describe_inference_recommendations_job.return_value = {


### PR DESCRIPTION
This pull request introduces new functionality to manage SageMaker Inference Recommender Jobs, including listing jobs, listing job steps, describing jobs, and stopping jobs. It also includes comprehensive test coverage for these new features.

### Additions to SageMaker Inference Recommender Job Management:

* Added helper functions in `sagemaker_ai_mcp_server/helpers.py` for:
  - Listing all inference recommender jobs (`list_inference_recommendations_jobs`).
  - Listing steps of a specific job (`list_inference_recommendations_job_steps`).
  - Describing a job (`describe_inference_recommendations_job`).
  - Stopping a job (`stop_inference_recommendations_job`).

* Integrated new tools in `sagemaker_ai_mcp_server/server.py` for:
  - Listing inference recommender jobs (`list_inference_recommendations_jobs_sagemaker`).
  - Listing job steps (`list_inference_recommendations_job_steps_sagemaker`).
  - Describing jobs (`describe_inference_recommendations_job_sagemaker`).
  - Stopping jobs (`stop_inference_recommendations_job_sagemaker`).

### Updates to Test Coverage:

* Added unit tests in `tests/test_helpers.py` for the new helper functions:
  - `test_list_inference_recommendations_jobs`.
  - `test_list_inference_recommendations_job_steps`.
  - `test_describe_inference_recommendations_job`.
  - `test_stop_inference_recommendations_job`.

* Added tests in `tests/test_server.py` for the new tools:
  - `test_list_inference_recommendations_jobs_sagemaker`.
  - `test_list_inference_recommendations_job_steps_sagemaker`.
  - `test_describe_inference_recommendations_job_sagemaker`.
  - `test_stop_inference_recommendations_job_sagemaker`.

### Minor Updates:

* Added `Optional` to the imports in `sagemaker_ai_mcp_server/helpers.py` to support type hinting for optional parameters.